### PR TITLE
Add networking, default mode for shared redis

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -26,13 +26,13 @@ services:
         '64mb',
       ]
     ports:
-      - '6379:6379'
+      - 6379:6379
     volumes:
-      - 'redis-data:/data'
+      - redis-data:/data
     networks:
       - sentry
     extra_hosts:
-      - "host.docker.internal:host-gateway" # Allow host.docker.internal to resolve to the host machine
+      - host.docker.internal:host-gateway # Allow host.docker.internal to resolve to the host machine
 
 volumes:
   redis-data:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -33,6 +33,7 @@ services:
       - sentry
     extra_hosts:
       - "host.docker.internal:host-gateway" # Allow host.docker.internal to resolve to the host machine
+
 volumes:
   sentry-redis:
 

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,14 +1,36 @@
 x-sentry-service-config:
   version: 0.1
-  service_name: shared-redis
+  service_name: redis
   dependencies:
-    shared-redis:
+    redis:
       description: Open-source, in-memory database that stores data as key-value pairs in RAM
   modes:
-    default: [shared-redis]
+    default: [redis]
 
 services:
-  shared-redis:
-    image: "redis:6.2.14-alpine"
+  redis:
+    image: ghcr.io/getsentry/image-mirror-library-redis:5.0-alpine
     healthcheck:
       test: redis-cli ping
+    command:
+      [
+        'redis-server',
+        '--appendonly',
+        'yes',
+        '--save',
+        '60',
+        '20',
+        '--auto-aof-rewrite-percentage',
+        '100',
+        '--auto-aof-rewrite-min-size',
+        '64mb',
+      ]
+    ports:
+      - '6379:6379'
+    networks:
+      - sentry
+
+networks:
+  sentry:
+    name: sentry # Uses environment variable if set, defaults to sentry-network
+    external: true  # Indicates this network is created externally

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -32,5 +32,4 @@ services:
 
 networks:
   sentry:
-    name: sentry # Uses environment variable if set, defaults to sentry-network
-    external: true  # Indicates this network is created externally
+    name: sentry

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -27,8 +27,12 @@ services:
       ]
     ports:
       - '6379:6379'
+    volumes:
+      - 'sentry-redis:/data'
     networks:
       - sentry
+volumes:
+  sentry-redis:
 
 networks:
   sentry:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,12 +1,14 @@
 x-sentry-service-config:
   version: 0.1
   service_name: shared-redis
-  dependencies: {}
+  dependencies:
+    shared-redis:
+      description: Open-source, in-memory database that stores data as key-value pairs in RAM
   modes:
-    default: []
-  
+    default: [shared-redis]
+
 services:
-  redis:
+  shared-redis:
     image: "redis:6.2.14-alpine"
     healthcheck:
       test: redis-cli ping

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -31,6 +31,8 @@ services:
       - 'sentry-redis:/data'
     networks:
       - sentry
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # Allow host.docker.internal to resolve to the host machine
 volumes:
   sentry-redis:
 

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,6 +1,6 @@
 x-sentry-service-config:
   version: 0.1
-  service_name: redis
+  service_name: shared-redis
   dependencies:
     redis:
       description: Open-source, in-memory database that stores data as key-value pairs in RAM
@@ -28,14 +28,14 @@ services:
     ports:
       - '6379:6379'
     volumes:
-      - 'sentry-redis:/data'
+      - 'redis-data:/data'
     networks:
       - sentry
     extra_hosts:
       - "host.docker.internal:host-gateway" # Allow host.docker.internal to resolve to the host machine
 
 volumes:
-  sentry-redis:
+  redis-data:
 
 networks:
   sentry:


### PR DESCRIPTION
Docker compose requires external network to communicate with other compose projects across the docker network

Also adds default mode which was not defined before